### PR TITLE
feat: rewrite fzf-menu; add preview, header, and deduplication

### DIFF
--- a/fzf-menu
+++ b/fzf-menu
@@ -1,15 +1,47 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
-IFS=':'
 
+GREEN_START='\033[01;32m'
+COLOR_RESET='\033[0m'
 get_selection() {
-  for p in $PATH; do
-    ls "$p"
+	{ get_applications; get_programs_in_path; } \
+		| fzf \
+		--ansi \
+		--preview="[[ {} == *'.desktop' ]] && cat \$(echo {} | awk '{print \$NF}') || echo \$(whatis {})" \
+		--preview-window=right:60%:wrap \
+		--bind=ctrl-space:toggle-preview \
+		--header="Select a program to launch"
+}
+
+get_programs_in_path() {
+  local pathDeduped=$(printf '%s\n' $PATH | tr ':' '\n' | uniq )
+  for p in $pathDeduped; do
+    find "$p"/ -maxdepth 1 -type f,l -executable -printf '%f\n' 2>/dev/null
   done \
-    | fzf
+    | awk '!x[$0]++'
+    # awk removes duplicates without sorting.  Thanks https://stackoverflow.com/a/11532197/6100005 \
+}
+
+get_applications() {
+    local applicationPathsDeduped=$(printf '%s\n' ${XDG_DATA_DIRS:-/usr/share} | tr ':' '\n' | uniq )
+    for p in $applicationPathsDeduped; do
+		for app in $(find "$p"/applications -maxdepth 1 -type f,l -name '*.desktop' 2>/dev/null); do
+			local appname=$(sed -n '0,/^Name=/{s/^Name=//p}' $app)
+			printf "${GREEN_START}$appname${COLOR_RESET} : $app\n"
+		done
+    done
+}
+
+launch() {
+	if [[ $1 == *'.desktop' ]]; then
+		#exec nohup zsh -c "(gio launch $1) & disown ; sleep 3"
+		exec nohup zsh -c "(setsid -f gio launch $1) & disown ; sleep 3"
+	else
+		exec setsid -f $1 > /dev/null 2>&1
+	fi
 }
 
 if selection=$( get_selection ); then
-  exec "$selection"
+	launch "$(echo $selection | awk '{print $NF}')"
 fi
 


### PR DESCRIPTION

Summary:

This diff upstreams a bunch of patches from
github.com/vegerot:dotfiles/bin/fzf-menu.  Notable changes include:

- work with both binaries in PATH and .desktop applications
- Add a preview window that shows the `whatis` output for the selected
  program, or the contents of the .desktop file if it's a .desktop file.
- Deduplicate the output of `get_programs_in_path` and `get_applications`
- fix several bugs.  The most important one being to not detach stdout for
  processes (like Discord) that require it.

```git
commit 82e8ba34b046b5a53ca9813c94c7603581f3128c
Author: Max 👨🏽‍💻 Coplan <mchcopl@gmail.com>
Date:   Sat Jul 20 15:01:15 2024 -0700

    fix(fzf-menu): give stdout and stderr to /dev/null when launching apps

commit 091797a03c25e286f21cbeb09725b0c019e0d92f
Author: Max 👨🏽‍💻 Coplan <mchcopl@gmail.com>
Date:   Fri Jun 21 18:59:31 2024 -0700

    fix(fzf-menu): use exec nohup to launch .desktop files

commit 7a2c8dfe7c22c26c8c18313e62819d1ed39cd314
Author: Max 👨🏽‍💻 Coplan <mchcopl@gmail.com>
Date:   Fri Jun 21 18:58:37 2024 -0700

    fix(fzf-menu): use setsid instead of nohup for launching applications

commit e1be3b3c4c09578889d78bc521ceffcce96cfe4d
Author: Max 👨🏽‍💻 Coplan <mchcopl@gmail.com>
Date:   Fri Jun 21 18:58:37 2024 -0700

    feat(fzf-menu): add support for .desktop files in /usr/share/applications

commit 622cf28161ff5639073a628896cb199a83b1b31c
Author: Max 👨🏽‍💻 Coplan <mchcopl@gmail.com>
Date:   Fri Jun 21 18:58:37 2024 -0700

    fix(fzf-menu): fix find command to only return files and symlinks that are executable

commit 33b49eb79ada41c7b9edc7d6ddd6650a9606a821
Author: Max 👨🏽‍💻 Coplan <mchcopl@gmail.com>
Date:   Fri Jun 21 18:58:37 2024 -0700

    refactor(fzf-menu): split out get_programs_in_path

commit 0993d0634042656a2df5a298b0e15c40889c0b4e
Author: Max 👨🏽‍💻 Coplan <mchcopl@gmail.com>
Date:   Fri Jun 21 18:58:37 2024 -0700

    feat(i3): add fzf-menu script
```

Test Plan:

1. Run `fzf-menu` and select a binary program to launch
2. Run `fzf-menu` and select a .desktop application to launch
3. ???
4. Profit
